### PR TITLE
adding Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine: 3.13
+
+RUN apk add openjdk11
+COPY


### PR DESCRIPTION
"gradle clean build" works only with jdk 21 un upper. have to change everywhere to jdk21
https://stackoverflow.com/questions/75035852/intellij-gradle-build-failure-incompatible-because-component-compatible-with-ja